### PR TITLE
AMB-1422: Removed pipeline variables in github action

### DIFF
--- a/.github/workflows/continuous-disintegration.yml
+++ b/.github/workflows/continuous-disintegration.yml
@@ -14,14 +14,9 @@ jobs:
         run: |
           echo "ACCESS_TOKEN"=$(curl 'https://app.vssps.visualstudio.com/oauth2/token' --data "client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion=${{ secrets.AZURE_DEVOPS_CLIENT_SECRET }}&grant_type=refresh_token&assertion=${{ secrets.AZURE_DEVOPS_REFRESH_TOKEN }}&redirect_uri=https://localhost:1337/callback" | jq -r '.access_token') >> $GITHUB_OUTPUT
 
-      - name: Get PR Number
-        run : |
-            echo PR-${{ github.event.number }}
-
       - name: Azure Pipelines Action
         uses: Azure/pipelines@v1.2
         with:
           azure-devops-project-url: 'https://dev.azure.com/NHSD-APIM/API%20Platform'
           azure-pipeline-name: 'gp-connect-access-record-fhir-pr-teardown'
           azure-devops-token: ${{ steps.get-access-token.outputs.ACCESS_TOKEN }}
-          azure-pipeline-variables: '{ "pr_number": "${{ github.event.number }}" }'

--- a/azure/azure-pr-teardown-pipeline.yml
+++ b/azure/azure-pr-teardown-pipeline.yml
@@ -1,10 +1,5 @@
 name: "$(SourceBranchName)+$(BuildID)"
 
-parameters:
-- name: pr_number
-  type: string
-  default: ""
-
 trigger: none
 pr: none
 


### PR DESCRIPTION
The current version of the Azure Github Action doesn't support passing values from the piplines variables to runtime parameters in an azure pipeline.

## Summary
* Routine Change
* :exclamation: Breaking Change
* :robot: Operational or Infrastructure Change
* :sparkles: New Feature
* :warning: Potential issues that might be caused by this change

Add any other relevant notes or explanations here. **Remove this line if you have nothing to add.**


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
