### PR TITLE
AMB-1475: Renamed pipeline var `pr_number`

### DIFF
--- a/azure/azure-pr-teardown-pipeline.yml
+++ b/azure/azure-pr-teardown-pipeline.yml
@@ -25,10 +25,6 @@ jobs:
       - checkout: self
 
       - bash: |
-          echo $(action_pr_number)
-          echo $(ACTION_PR_NUMBER)
-          echo $[variables['action_pr_number']]
-          echo ${{variables['action_pr_number']}}
           WORKSPACE="pr-"$(ACTION_PR_NUMBER)
           echo $WORKSPACE
           echo "##vso[task.setvariable variable=WORKSPACE]$WORKSPACE"

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -17,7 +17,7 @@ workspace:
 	$(tf_cmd) workspace new $(environment) || $(tf_cmd) workspace select $(environment) && echo "Switched to workspace/environment: $(environment)"
 
 init:
-	$(tf_cmd) init $(tf_state) $(tf_vars)
+	$(tf_cmd) init $(tf_state) $(tf_vars) -upgrade
 
 plan: workspace
 	 $(tf_cmd) plan $(tf_vars)

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -17,7 +17,7 @@ workspace:
 	$(tf_cmd) workspace new $(environment) || $(tf_cmd) workspace select $(environment) && echo "Switched to workspace/environment: $(environment)"
 
 init:
-	$(tf_cmd) init $(tf_state) $(tf_vars) -upgrade
+	$(tf_cmd) init $(tf_state) $(tf_vars)
 
 plan: workspace
 	 $(tf_cmd) plan $(tf_vars)


### PR DESCRIPTION
## Summary
* :robot: Operational or Infrastructure Change

We have a pr_number variable in `project.yml` that is used on the pr-pipeline at compile-time.

In order to prevent clashes with this, the variable declared on the pipeline UI has been renamed to `action_pr_number`.

This variable is overriden via the github action triggered on a PR close event and MUST be set on the pipeline, not in the yaml, as we can't override variable values declared in the yaml files.
